### PR TITLE
Encapsulated key parameters in functions

### DIFF
--- a/BlobStorageMgt.codeunit.al
+++ b/BlobStorageMgt.codeunit.al
@@ -12,9 +12,9 @@ codeunit 50101 BlobStorageManagement
         ContainerContentText: Text;
     begin
         Authorization := StorageServiceAuthorization.CreateSharedKey(GetSharedKey());
-        ContainerClient.Initialize('MY_STORAGE_ACCOUNT', Authorization);
+        ContainerClient.Initialize(GetStorageAccount(), Authorization);
         //Create container
-        Response := ContainerClient.CreateContainer('mycontainer');
+        Response := ContainerClient.CreateContainer(GetContainerName());
         //List containers
         Response := ContainerClient.ListContainers(Containers);
         if Response.IsSuccessful() then begin
@@ -27,7 +27,7 @@ codeunit 50101 BlobStorageManagement
             Message('Error: %1', Response.GetError());
 
         //Init Blob Client
-        BlobClient.Initialize('MY_STORAGE_ACCOUNT', 'mycontainer', Authorization);
+        BlobClient.Initialize(GetStorageAccount(), GetContainerName(), Authorization);
         //Create a blob (text content)
         Response := BlobClient.PutBlobBlockBlobText('MyBlob', 'This is the content of my blob');
         if not Response.IsSuccessful() then
@@ -48,7 +48,22 @@ codeunit 50101 BlobStorageManagement
         end;
     end;
 
-    local procedure GetSharedKey(): SecretText
+    [NonDebuggable]
+    internal procedure GetSharedKey(): SecretText
+    begin
+
+    end;
+
+
+    [NonDebuggable]
+    internal procedure GetStorageAccount(): Text
+    begin
+
+    end;
+
+
+    [NonDebuggable]
+    internal procedure GetContainerName(): Text
     begin
 
     end;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Low code churn, but it changes how storage account/container/key values are sourced; the new helper procedures are currently empty, so blob operations will fail until implemented.
> 
> **Overview**
> Replaces hard-coded Azure Blob Storage identifiers (account and container) with calls to new helper procedures (`GetStorageAccount`, `GetContainerName`, `GetSharedKey`) when initializing `ContainerClient`/`BlobClient` and creating the container.
> 
> Adds `[NonDebuggable] internal` helper procedures intended to encapsulate these sensitive/configuration values, and removes the previous `local` `GetSharedKey` stub in favor of this new internal API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dd49622776c976124198f39d972a7f11c524820. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->